### PR TITLE
[FEATURE] Dagger Core Module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "buildscript"]
-	path = buildscript
-	url = git@github.com:aeccue/gradle.git

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.aeccue:gradle:0.1.1")
+        classpath("com.aeccue:gradle:0.1.2")
     }
 }
 
@@ -16,8 +16,4 @@ apply(plugin = com.aeccue.gradle.Plugins.Aeccue.PROJECT_KOTLIN)
 subprojects {
     group = "${rootProject.group}.foundation"
     version = rootProject.version
-}
-
-dependencies {
-    "api"(project(":dagger"))
 }

--- a/dagger/build.gradle.kts
+++ b/dagger/build.gradle.kts
@@ -1,7 +1,3 @@
 subprojects {
     apply(plugin = com.aeccue.gradle.Plugins.Aeccue.DAGGER_LIBRARY)
 }
-
-dependencies {
-    api(project(":dagger:dagger-core"))
-}

--- a/dagger/build.gradle.kts
+++ b/dagger/build.gradle.kts
@@ -1,3 +1,7 @@
 subprojects {
     apply(plugin = com.aeccue.gradle.Plugins.Aeccue.DAGGER_LIBRARY)
 }
+
+dependencies {
+    api(project(":dagger:dagger-core"))
+}

--- a/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/component/BaseDaggerComponent.kt
+++ b/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/component/BaseDaggerComponent.kt
@@ -1,0 +1,24 @@
+package com.aeccue.foundation.dagger.component
+
+import com.aeccue.foundation.dagger.injector.DaggerInjection
+import com.aeccue.foundation.dagger.injector.DaggerInjectorProvider
+import com.aeccue.foundation.dagger.injector.Injectable
+
+abstract class BaseDaggerComponent<T> {
+
+    interface Factory<T> {
+
+        fun create(): BaseDaggerComponent<T>
+    }
+
+    protected abstract fun inject(target: T)
+
+    fun init(target: T) {
+        (target as? Injectable)?.preInject()
+        inject(target)
+        (target as? Injectable)?.postInject()
+        (target as? DaggerInjectorProvider)?.provide()?.let {
+            DaggerInjection.register(it)
+        }
+    }
+}

--- a/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/component/BaseDaggerSubcomponent.kt
+++ b/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/component/BaseDaggerSubcomponent.kt
@@ -1,0 +1,24 @@
+package com.aeccue.foundation.dagger.component
+
+import dagger.Binds
+import dagger.BindsInstance
+import dagger.multibindings.IntoSet
+
+interface BaseDaggerSubcomponent<in T> {
+
+    abstract class Factory<T, out C : BaseDaggerSubcomponent<T>> {
+
+        abstract val key: Class<T>
+
+        abstract fun create(@BindsInstance target: T): C
+    }
+
+    interface FactoryMapping<T, C : BaseDaggerSubcomponent<T>, F : Factory<T, C>> {
+
+        @Binds
+        @IntoSet
+        fun mapping(factory: F): Factory<Any, BaseDaggerSubcomponent<Any>>
+    }
+
+    fun inject(target: T)
+}

--- a/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/injector/DaggerInjection.kt
+++ b/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/injector/DaggerInjection.kt
@@ -14,9 +14,7 @@ object DaggerInjection {
 
     fun inject(target: Any) {
         for (injector in injectors) {
-            if (injector.inject(target)) {
-                return
-            }
+            if (injector.inject(target)) return
         }
 
         throw IllegalArgumentException("Dagger injector does not exist for target [${target::class.simpleName}]")

--- a/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/injector/DaggerInjection.kt
+++ b/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/injector/DaggerInjection.kt
@@ -1,0 +1,24 @@
+package com.aeccue.foundation.dagger.injector
+
+object DaggerInjection {
+
+    private val injectors = mutableListOf<DaggerInjector>()
+
+    fun register(injector: DaggerInjector) {
+        injectors.add(injector)
+    }
+
+    fun unregister(injector: DaggerInjector) {
+        injectors.remove(injector)
+    }
+
+    fun inject(target: Any) {
+        for (injector in injectors) {
+            if (injector.inject(target)) {
+                return
+            }
+        }
+
+        throw IllegalArgumentException("Dagger injector does not exist for target [${target::class.simpleName}]")
+    }
+}

--- a/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/injector/DaggerInjector.kt
+++ b/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/injector/DaggerInjector.kt
@@ -1,0 +1,22 @@
+package com.aeccue.foundation.dagger.injector
+
+import com.aeccue.foundation.dagger.component.BaseDaggerSubcomponent
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DaggerInjector
+@Inject constructor(factories: Set<@JvmSuppressWildcards BaseDaggerSubcomponent.Factory<Any, BaseDaggerSubcomponent<Any>>>) {
+
+    private val factoryMappings = factories.associateBy {
+        it.key
+    }
+
+    fun inject(target: Any): Boolean {
+        val factory = factoryMappings[target::class.java] ?: return false
+        (target as? Injectable)?.preInject()
+        factory.create(target).inject(target)
+        (target as? Injectable)?.postInject()
+        return true
+    }
+}

--- a/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/injector/DaggerInjectorProvider.kt
+++ b/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/injector/DaggerInjectorProvider.kt
@@ -1,0 +1,6 @@
+package com.aeccue.foundation.dagger.injector
+
+interface DaggerInjectorProvider {
+
+    fun provide(): DaggerInjector
+}

--- a/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/injector/Injectable.kt
+++ b/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/injector/Injectable.kt
@@ -1,0 +1,8 @@
+package com.aeccue.foundation.dagger.injector
+
+interface Injectable {
+
+    fun preInject() {}
+
+    fun postInject() {}
+}

--- a/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/module/DaggerInjectorModule.kt
+++ b/dagger/core/src/main/kotlin/com/aeccue/foundation/dagger/module/DaggerInjectorModule.kt
@@ -1,0 +1,12 @@
+package com.aeccue.foundation.dagger.module
+
+import com.aeccue.foundation.dagger.component.BaseDaggerSubcomponent
+import dagger.Module
+import dagger.multibindings.Multibinds
+
+@Module
+interface DaggerInjectorModule {
+
+    @Multibinds
+    fun factories(): Set<BaseDaggerSubcomponent.Factory<Any, BaseDaggerSubcomponent<Any>>>
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,12 +1,12 @@
 rootProject.name = "foundation"
 
 if (gradle.parent == null) {
-    includeBuild("buildscript")
+    includeBuild("../gradle")
 }
 
 include(
-        ":dagger",
-        ":dagger:core"
+        "dagger",
+        "dagger:core"
 )
 
 project(":dagger:core").name = "dagger-core"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,5 +5,8 @@ if (gradle.parent == null) {
 }
 
 include(
-        ":dagger"
+        ":dagger",
+        ":dagger:core"
 )
+
+project(":dagger:core").name = "dagger-core"


### PR DESCRIPTION
## BaseDaggerComponent
This class should be extended by all dagger components. It contains the factory to create the component and a init method that will inject the target and register it to DaggerInjection. This init method must be invoked to allow dagger injection to work on any subcomponents and modules.

## BaseDaggerSubcomponent
This class should be extended by all dagger subcomponents. The FactoryMapping must also be extended and included as a module to the component to insert the mapping into the DaggerInjector. The Factory must also provide a key for this mapping.

## DaggerInjection
Registers DaggerInjectors and delegates injection to the proper DaggerInjector. DaggerInjector will contains all subcomponent mappings in its  component and which it will create and use for injections. 